### PR TITLE
feat(config): add support any plugins/presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ provides an interface to [remark-lint](https://github.com/remarkjs/remark-lint).
 It will be used with files that have the “markdown" syntax.
 
 ## Installation
+
 SublimeLinter must be installed in order to use this plugin.
 
 Please use [Package Control](https://packagecontrol.io) to install the linter
@@ -14,14 +15,24 @@ plugin.
 
 Before installing this plugin, you must ensure that `remark-lint` is installed
 on your system. This can be done using the command:
+
 ```bash
-sudo npm install -g remark remark-preset-lint-markdown-style-guide
+(sudo) npm install -g remark
 ```
+
+Then install [presets](https://www.npmjs.com/search?q=remark-preset)
+and/or [plugins](https://github.com/remarkjs/remark/blob/master/doc/plugins.md), that yo want. Example:
+
+```bash
+(sudo) npm install -g remark-preset-lint-markdown-style-guide
+```
+
 See <https://github.com/remarkjs/remark-lint> for more details.
 
 In order for `remark-lint` to be executed by SublimeLinter, you must ensure
 that its path is available to SublimeLinter. The docs cover [troubleshooting PATH configuration](http://sublimelinter.readthedocs.io/en/latest/troubleshooting.html#finding-a-linter-executable).
 
 ## Settings
+
 - SublimeLinter settings: <http://sublimelinter.readthedocs.org/en/latest/settings.html>
 - Linter settings: <http://sublimelinter.readthedocs.org/en/latest/linter_settings.html>

--- a/README.md
+++ b/README.md
@@ -1,38 +1,37 @@
-# SublimeLinter-contrib-remark-lint
+## 1. SublimeLinter-contrib-remark-lint
 
-[![Build Status](https://travis-ci.org/SublimeLinter/SublimeLinter-contrib-remark-lint.svg?branch=master)](https://travis-ci.org/SublimeLinter/SublimeLinter-contrib-remark-lint)
+This linter plugin for [**SublimeLinter**](https://github.com/SublimeLinter/SublimeLinter)
+provides an interface to [**remark-lint**](https://github.com/remarkjs/remark-lint).
+It will be used with files that have the “Markdown" syntax.
 
-This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter)
-provides an interface to [remark-lint](https://github.com/remarkjs/remark-lint).
-It will be used with files that have the “markdown" syntax.
-
-## Installation
+## 2. Installation
 
 SublimeLinter must be installed in order to use this plugin.
 
-Please use [Package Control](https://packagecontrol.io) to install the linter
+Please use [**Package Control**](https://packagecontrol.io) to install the linter
 plugin.
 
-Before installing this plugin, you must ensure that `remark-lint` is installed
+Before installing this plugin, you must ensure that remark-cli is installed
 on your system. This can be done using the command:
 
-```bash
-(sudo) npm install -g remark
+```shell
+npm install --global remark-cli
 ```
 
-Then install [presets](https://www.npmjs.com/search?q=remark-preset)
-and/or [plugins](https://github.com/remarkjs/remark/blob/master/doc/plugins.md), that yo want. Example:
+Your [**presets**](https://www.npmjs.com/search?q=remark-preset) and/or [**rules**](https://github.com/remarkjs/remark-lint#rules) must be installed locally. Example command:
 
-```bash
-(sudo) npm install -g remark-preset-lint-markdown-style-guide
+```shell
+npm install --save-dev remark-preset-lint-markdown-style-guide preset-lint-recommended
 ```
 
-See <https://github.com/remarkjs/remark-lint> for more details.
+See **<https://github.com/remarkjs/remark-lint>** for more details.
 
-In order for `remark-lint` to be executed by SublimeLinter, you must ensure
-that its path is available to SublimeLinter. The docs cover [troubleshooting PATH configuration](http://sublimelinter.readthedocs.io/en/latest/troubleshooting.html#finding-a-linter-executable).
+You must have the [**Remark configuration file**](https://github.com/remarkjs/remark/tree/main/packages/remark-cli#example-config-files-json-yaml-js).
 
-## Settings
+In order for remark-cli to be executed by SublimeLinter, you must ensure
+that its path is available to SublimeLinter. The docs cover [**troubleshooting PATH configuration**](http://sublimelinter.readthedocs.io/en/latest/troubleshooting.html#finding-a-linter-executable).
 
-- SublimeLinter settings: <http://sublimelinter.readthedocs.org/en/latest/settings.html>
-- Linter settings: <http://sublimelinter.readthedocs.org/en/latest/linter_settings.html>
+## 3. Settings
+
+1. SublimeLinter settings: **<http://sublimelinter.readthedocs.org/en/latest/settings.html>**
+1. Linter settings: **<http://sublimelinter.readthedocs.org/en/latest/linter_settings.html>**

--- a/linter.py
+++ b/linter.py
@@ -1,13 +1,30 @@
-from SublimeLinter.lint import Linter, util
+"""SublimeLinter-remark."""
+from SublimeLinter.lint import Linter
+from SublimeLinter.lint import util
 
 
-class RemarkLint(Linter):
-    cmd = ("remark", "--use", "remark-preset-lint-markdown-style-guide")
+class RemarkLint(Linter):  # pylint: disable=too-few-public-methods
+    """remark implementation for SublimeLinter.
+
+    Lint Markdown via remark:
+    https://remark.js.org/
+
+    Extends:
+        Linter
+
+    Variables:
+        cmd {string} -- remark command
+        regex {tuple} -- parsing regex
+        error_stream {string} -- parse STDERR
+        defaults {dict} -- scopes, where remark will accepted
+    """
+
+    cmd = 'remark --no-stdout'
     regex = (
         r'^\s+(?P<line>\d+):(?P<col>\d+)(?:-\d+:\d+)?\s{2}'
         r'(?P<error>error)?(?P<warning>warning)?\s{2}'
         r'(?P<message>(?:\S+)(?:\s{1}\S+)*)(?:\s{2,}\S+\s{2,}\S+)?$'
-        )
+    )
     error_stream = util.STREAM_STDERR
     defaults = {
         "selector": "text.html.markdown"

--- a/linter.py
+++ b/linter.py
@@ -1,31 +1,69 @@
-"""SublimeLinter-remark."""
+"""[OVERVIEW] SublimeLinter plugin for Remark.
+
+[REMARK][INFO] Remark — the ecosystem of plugins that work with Markdown:
+https://remark.js.org/
+
+[REMARK][INFO] remark-cli — the command-line Remark interface.
+https://github.com/remarkjs/remark/tree/main/packages/remark-cli
+
+[REMARK][INFO] remark-lint — Remark plugins for checking Markdown code style:
+https://github.com/remarkjs/remark-lint
+
+[REMARK][INFO] remark-parse — the default Markdown parser of Remark:
+https://github.com/remarkjs/remark/tree/main/packages/remark-parse
+"""
 from SublimeLinter.lint import Linter
 from SublimeLinter.lint import util
 
 
 class RemarkLint(Linter):  # pylint: disable=too-few-public-methods
-    """remark implementation for SublimeLinter.
+    """[CLASS_DESCRIPTION] Parse Remark output with SublimeLinter.
 
-    Lint Markdown via remark:
-    https://remark.js.org/
+    [LEARN][SUBLIMELINTER] Attributes of SublimeLinter plugins:
+    https://sublimelinter.readthedocs.io/en/latest/linter_attributes.html
 
     Extends:
         Linter
 
     Variables:
-        cmd {string} -- remark command
-        regex {tuple} -- parsing regex
-        error_stream {string} -- parse STDERR
-        defaults {dict} -- scopes, where remark will accepted
+        1. cmd {string} -- the remark-cli command
+        2. defaults {dict} -- scopes for SublimeLinter Remark plugin
+        3. error_stream {string} -- capture Remark standard streams
+        4. regex {regex} -- the regular expression for parsing remark-cli stderr
     """
 
-    cmd = 'remark --no-stdout'
-    regex = (
-        r'^\s+(?P<line>\d+):(?P<col>\d+)(?:-\d+:\d+)?\s{2}'
-        r'(?P<error>error)?(?P<warning>warning)?\s{2}'
-        r'(?P<message>(?:\S+)(?:\s{1}\S+)*)(?:\s{2,}\S+\s{2,}\S+)?$'
-    )
-    error_stream = util.STREAM_STDERR
+    # [CLI][REMARK] “--no-stdout” — don’t print file content to console
+    #
+    # [LEARN][SUBLIMELINTER] “${args}” — additional user arguments for remark-cli command:
+    # https://sublimelinter.readthedocs.io/en/latest/linter_attributes.html#cmd-mandatory
+    cmd = "remark --no-stdout ${args}"
+
+    # [SUBLIME][INFO] “text.html.markdown” is the syntax scope of the “Markdown” syntax
+    # from the “MarkdownEditing” package:
+    # https://github.com/SublimeText-Markdown/MarkdownEditing/blob/88499d3bc4d25eedf472aff7cf160d82b1713182/syntaxes/Markdown.sublime-syntax#L13
+    #
+    # [LEARN][SUBLIME] “Syntax scopes” in Sublime Text:
+    # https://kristinita.netlify.app/it-articles/how-to-get-current-%E2%80%A6-in-sublime-text#Syntax-scope
     defaults = {
         "selector": "text.html.markdown"
     }
+
+    # [REMARK][INFO] Remark returns warnings solely to stderr
+    error_stream = util.STREAM_STDERR
+
+    # [REMARK][INFO] remark-lint returns solely warnings, not errors:
+    # https://github.com/remarkjs/remark-lint#configure
+    #
+    # [LEARN][MARKDOWN] Markdown hasn’t such thing as “non-valid syntax”,
+    # therefore, Markdown parsers doesn’t return parsing errors:
+    # https://stackoverflow.com/a/5508742/5951529
+    #
+    #
+    # [REMARK][REPORTER] vfile-reporter is the default reporter for remark-lint:
+    # https://github.com/unifiedjs/unified-args#--report-reporter
+    # https://github.com/vfile/vfile-reporter
+    #
+    # [REMARK][REPORTER] Example output of vfile-reporter:
+    # 5:3      warning Remove 1 line before node  no-consecutive-blank-lines  remark-lint
+    # 5:3-5:10 warning Marker style should be `+` unordered-list-marker-style remark-lint
+    regex = r"^(?P<line>\d+):(?P<col>\d+)(?:-\d+:\d+)?\s+(?P<warning>warning)\s+(?P<message>.*)$"


### PR DESCRIPTION
### 1. Summary

I change remark command in `linter.py`, that:

1. any custom remark configuration will support
1. user doesn't get any errors, if file valid

### 2. Configuration

Remark has many [**presets**](https://www.npmjs.com/search?q=remark-preset) and [**plugins**](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins). User can set any custom configuration, see [**my `.remarkrc.yaml`**](https://www.pastery.net/msgugw/) for example.

We shouldn't impose default settings on a single preset on users. I remove `--use remark-preset-lint-markdown-style-guide` from `linter.py`.

### 3. Non-errored file

#### 3.1. Behavior before pull-request

+ We have valid Markdown file.

```markdown
Kira Goddess!
```

+ Before:

![Before](https://i.imgur.com/pgdmFYC.png)

+ CLI output:

```text
D:\SashaDebugging>remark KiraRemark.md
Kira Goddess!
KiraRemark.md: no issues found
```

File content is copied to output.

#### 3.2. Behavior after pull-request

I add [**`--no-stdout` option**](https://github.com/remarkjs/remark/tree/master/packages/remark-cli#cli), that file content not copied to output.

+ After:

![After](https://i.imgur.com/vXk0dJP.png)

### 4. Testing environment

+ Windows 10 Enterprise LTSB 64-bit EN
+ Sublime Text 3.1.1, Build 3176
+ SublimeLinter 4.9.4
+ SublimeLinter-contrib-remark 1.0.0

Thanks.
